### PR TITLE
Toggle between geometry and place

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -292,30 +292,6 @@
             <div
               style="position: absolute; z-index: 1; bottom: 0px; left: 0px"
             >
-              <div class="custom-control custom-switch ml-1">
-                <input
-                  id="surfaceSwitch"
-                  v-model="highlightSurface"
-                  type="checkbox"
-                  class="custom-control-input"
-                >
-                <label
-                  class="custom-control-label"
-                  for="surfaceSwitch"
-                >Select surface</label>
-              </div>
-              <div class="custom-control custom-switch ml-1">
-                <input
-                  id="semanticsSwitch"
-                  v-model="showSemantics"
-                  type="checkbox"
-                  class="custom-control-input"
-                >
-                <label
-                  class="custom-control-label"
-                  for="semanticsSwitch"
-                >Semantics</label>
-              </div>
               <div
                 class="btn-group ml-1 mb-1 bg-white"
                 role="group"
@@ -323,19 +299,17 @@
               >
                 <button
                   type="button"
-                  :class="['btn', activeLoD == - 1 ? 'btn-primary' : 'btn-outline-primary']"
-                  @click="activeLoD = - 1"
+                  :class="['btn', toggleGeometryPlace === 0 ? 'btn-primary' : 'btn-outline-primary']"
+                  @click="toggleGeometryPlace = 0"
                 >
-                  All
+                  geometry
                 </button>
                 <button
-                  v-for="( lod, idx ) in availableLoDs"
-                  :key="lod"
                   type="button"
-                  :class="['btn', activeLoD == idx ? 'btn-primary' : 'btn-outline-primary']"
-                  @click="activeLoD = idx"
+                  :class="['btn', toggleGeometryPlace === 1 ? 'btn-primary' : 'btn-outline-primary']"
+                  @click="toggleGeometryPlace = 1"
                 >
-                  LoD{{ lod }}
+                  place
                 </button>
               </div>
             </div>
@@ -468,8 +442,7 @@ export default {
 			selectionColor: 0xffc107,
 			showSemantics: true,
 			highlightSurface: false,
-			availableLoDs: [],
-			activeLoD: - 1,
+			toggleGeometryPlace: 0, // 0: geometry, 1: place
 			cameraLight: false
 		};
 


### PR DESCRIPTION
Added the geometry/place toggle in the view. The `toggleGeometryPlace` event, which technically replaces the `activeLoD` event in ninja. @Ylannl you can check `toggleGeometryPlace` in the Threejs component, where `0` is *geometry* and `1` is *place*.
Closes #2 